### PR TITLE
Fix opam CI timeouts during build

### DIFF
--- a/dune
+++ b/dune
@@ -15,7 +15,7 @@
      vendor/cadical
      (progn
       (bash "CXXFLAGS=-fPIC ./configure")
-      (run make)))
+      (bash "make -j $(opam var jobs)")))
     (copy vendor/cadical/build/libcadical.a libcadical.a)
     (chdir
      vendor/libpoly
@@ -28,7 +28,7 @@
        -DCMAKE_INSTALL_PREFIX=$prefix)
       (chdir
        build
-       (run make))
+       (bash "make -j $(opam var jobs)"))
       (run mv include poly)))
     (copy vendor/libpoly/build/src/libpicpoly.a libpicpoly.a)
     (copy vendor/libpoly/build/src/libpicpolyxx.a libpicpolyxx.a)
@@ -36,7 +36,7 @@
      vendor/cvc5
      (progn
       (bash "./configure.sh --static")
-      (run make -C build)))
+      (bash "make -C build -j $(opam var jobs)")))
     (copy vendor/cvc5/build/src/libcvc5.a libcvc5.a)
     (copy vendor/cvc5/build/include/cvc5/cvc5_export.h cvc5_export.h)))))
 


### PR DESCRIPTION
Use opam's `jobs` variable to build the package