### PR TITLE
Support shared library in addition to static

### DIFF
--- a/dune
+++ b/dune
@@ -7,7 +7,7 @@
 (rule
  (deps
   (source_tree vendor))
- (targets libpicpolyxx.a libpicpoly.a libcadical.a libcvc5.a cvc5_export.h)
+ (targets libpicpolyxx.a libpicpoly.a libcadical.a libcvc5.a cvc5_export.h dllcadical.so dllpicpoly.so dllpicpolyxx.so dllcvc5.so)
  (action
   (no-infer
    (progn
@@ -20,24 +20,31 @@
     (chdir
      vendor/libpoly
      (progn
-      (run
-       cmake
-       -B
-       build
-       -DCMAKE_BUILD_TYPE=$type
-       -DCMAKE_INSTALL_PREFIX=$prefix)
-      (chdir
-       build
-       (bash "make -j $(opam var jobs)"))
-      (run mv include poly)))
+       (run
+        cmake
+        -B
+        build
+        -DCMAKE_BUILD_TYPE=$type
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+        -DCMAKE_INSTALL_PREFIX=$prefix)
+       (chdir
+        build
+        (bash "make -j $(opam var jobs)"))
+       (run mv include poly)
+       (run ln -sf poly include)))
     (copy vendor/libpoly/build/src/libpicpoly.a libpicpoly.a)
     (copy vendor/libpoly/build/src/libpicpolyxx.a libpicpolyxx.a)
     (chdir
      vendor/cvc5
      (progn
-      (bash "./configure.sh --static")
-      (bash "make -C build -j $(opam var jobs)")))
+      (bash "sed -i 's/set(CMAKE_FIND_LIBRARY_SUFFIXES .a)/set(CMAKE_FIND_LIBRARY_SUFFIXES .so .dylib .a)/' CMakeLists.txt")
+      (bash "CFLAGS=-fPIC CXXFLAGS=-fPIC ./configure.sh --static -DCMAKE_PREFIX_PATH=$(pkg-config --variable=prefix gmp)")
+      (bash "make -C build -j $(opam var jobs) cvc5")))
     (copy vendor/cvc5/build/src/libcvc5.a libcvc5.a)
+    (bash "g++ -shared -fPIC -o dllcadical.so -Wl,--whole-archive libcadical.a -Wl,--no-whole-archive")
+    (bash "g++ -shared -fPIC -o dllpicpoly.so -Wl,--whole-archive libpicpoly.a -Wl,--no-whole-archive")
+    (bash "g++ -shared -fPIC -o dllpicpolyxx.so -Wl,--whole-archive libpicpolyxx.a -Wl,--no-whole-archive ./dllpicpoly.so")
+    (bash "g++ -shared -fPIC -o dllcvc5.so -Wl,--whole-archive libcvc5.a -Wl,--no-whole-archive ./dllcadical.so ./dllpicpoly.so ./dllpicpolyxx.so -lgmp")
     (copy vendor/cvc5/build/include/cvc5/cvc5_export.h cvc5_export.h)))))
 
 (subdir
@@ -52,7 +59,6 @@
  (public_name cvc5)
  (name cvc5)
  (modules cvc5 cvc5_enums cvc5_external)
- (no_dynlink)
  (foreign_stubs
   (language cxx)
   (names cvc5_stubs)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "OCaml development environment";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      # Define supported systems
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+
+      # Helper function to generate attributes for each system
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          pythonWithPkgs = pkgs.python313.withPackages (ps: with ps; [
+            pyparsing
+            tomli
+          ]);
+        in
+        {
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              opam
+              pkg-config
+              pythonWithPkgs
+            ];
+
+            buildInputs = with pkgs; [
+              zlib
+              gmp.dev
+              gmpxx
+              m4
+              flint
+              cmake
+            ];
+
+            shellHook = ''
+              export PATH="${pythonWithPkgs}/bin:$PATH"
+              export NIX_PYTHONPATH="${pythonWithPkgs}/lib/python3.13/site-packages"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Build vendored C++ libs with -fPIC so they can be embedded in the OCaml shared plugin.

Replace `(no_dynlink)` with `(modes native)` to produce both `.cmxa` and `.cmxs` archives (not 100% sure this is necessary, but it works so I'm afraid to remove it now).

Pass GMP paths to cvc5's cmake via pkg-config so it finds system GMP on non-standard install paths.

Fix libpoly include symlink to not break cvc5'c cmake configuration.

Depens on #41 (Not stacking the PR so I can see the CI result)