### PR TITLE
Use our own ocaml docker images in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,28 +13,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
         ocaml-compiler:
           - "4.14"
-          - "5.3"
-    runs-on: ${{ matrix.os }}
+          - "5.4"
+
+    runs-on: ubuntu-latest
+    container: ghcr.io/formalsec/ocaml-${{ matrix.ocaml-compiler }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Setup OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          dune-cache: true
-          allow-prerelease-opam: true
+
       - name: Install dependencies
         run: |
           sudo apt update
+          opam update
           opam install -y . --deps-only --with-test
+
       - name: Build
-        run: opam exec -- dune build @install
+        run: dune build @install
+
       - name: Test
-        run: opam exec -- dune runtest
+        run: dune runtest


### PR DESCRIPTION
Avoids compiling the OCaml compiler each time. Hopefully we gain a few minutes during CI.